### PR TITLE
Blkfltchr/single recipe changes

### DIFF
--- a/src/components/SingleRecipe/index.js
+++ b/src/components/SingleRecipe/index.js
@@ -58,7 +58,7 @@ class SingleRecipe extends Component {
       title,
       description,
       image,
-      // ingredients,
+      ingredients,
       instructions,
       meal,
       preptime,
@@ -87,9 +87,11 @@ class SingleRecipe extends Component {
         <div>
           <p>{description}</p>
           <p>{instructions}</p>
-          {/* {ingredients.map((index, ingredient) =>
-            <p key={index} className='recipe-ingredients'>{ingredient}</p>
-          )} */}
+          <p> Ingredients:{' '}
+            {ingredients.map((ingredient, index) =>
+              <span key={index} className='recispane-ingredients'>{ingredient}, </span>
+            )}
+          </p>
           <p>{preptime} minutes preptime</p>
           <p>{meal}</p>
         </div>

--- a/src/components/SingleRecipe/index.js
+++ b/src/components/SingleRecipe/index.js
@@ -58,7 +58,7 @@ class SingleRecipe extends Component {
       title,
       description,
       image,
-      ingredients,
+      // ingredients,
       instructions,
       meal,
       preptime,
@@ -69,6 +69,7 @@ class SingleRecipe extends Component {
       return <h1>Loading...</h1>
     }
 
+    console.log(this.state)
     return (
       <div className='recipe-card'>
         <div className='flex-wrapper'>
@@ -77,23 +78,23 @@ class SingleRecipe extends Component {
 
         <div className='delete-flex'>
           <h3>{title}</h3>
-          <div>
+          {/* <div>
             <i className='far fa-edit fa-2x' />
             <i className='far fa-trash-alt fa-2x delete-icon' />
-          </div>
+          </div> */}
         </div>
 
         <div>
-          <h5 className='recipe-description'>{description}</h5>
-          <h5 className='recipe-instructions'>{instructions}</h5>
-          {ingredients.map((index, ingredient) =>
-            <h5 key={index} className='recipe-ingredients'>{ingredient}</h5>
-          )}
-          <h5 className='recipe-preptime'>{preptime}</h5>
-          <h5 className='recipe-meail'>{meal}</h5>
+          <p>{description}</p>
+          <p>{instructions}</p>
+          {/* {ingredients.map((index, ingredient) =>
+            <p key={index} className='recipe-ingredients'>{ingredient}</p>
+          )} */}
+          <p>{preptime} minutes preptime</p>
+          <p>{meal}</p>
         </div>
 
-        <div className='modal fade'>
+        {/* <div className='modal fade'>
           <div className='modal-dialog'>
             <div className='modal-content'>
               <div className='modal-header'>
@@ -125,7 +126,7 @@ class SingleRecipe extends Component {
               </div>
             </div>
           </div>
-        </div>
+        </div> */}
       </div>
     )
   }


### PR DESCRIPTION
# Description

I made two small changes to `SingleRecipe.js`:

1. I commented out unnecessary code (Modal, Delete, and Edit buttons)
2. I changed the order of `(index, ingredient)` to
 ```
{ingredients.map((ingredient, index) =>
              <span key={index} className='recispane-ingredients'>{ingredient}, </span>
            )}
```
which made `ingredient`-s instead of `index` numbers render to the screen!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings